### PR TITLE
Add custom PPA for librdkafka 1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - $HOME/.opam
 addons:
   apt:
+    sources:
+    - sourceline: 'ppa:leonidas/librdkafka'
     packages:
     - librdkafka-dev
 env:


### PR DESCRIPTION
The package was backported from Ubuntu focal, which is why it is 1.2. The integration tests now all pass.

Still confused why they don't when I run it locally.