### PR TITLE
Remove wrapping of `Kafka.topic`

### DIFF
--- a/lib/kafka.ml
+++ b/lib/kafka.ml
@@ -71,7 +71,7 @@ external new_topic :
   -> topic
   = "ocaml_kafka_new_topic"
 external destroy_topic : topic -> unit = "ocaml_kafka_destroy_topic"
-external topic_name : topic -> string = "ocaml_kafka_topic_name" [@@noalloc]
+external topic_name : topic -> string = "ocaml_kafka_topic_name"
 
 (*
   Note that the id is restricted to be some int value.

--- a/lib/ocaml_kafka.c
+++ b/lib/ocaml_kafka.c
@@ -328,7 +328,7 @@ value ocaml_kafka_destroy_topic(value caml_kafka_topic)
 
   rd_kafka_topic_t *topic = handler_val(caml_kafka_topic);
   if (topic) {
-    free_caml_handler(Field(caml_kafka_topic, 0));
+    free_caml_handler(caml_kafka_topic);
     rd_kafka_topic_destroy(topic);
   }
 

--- a/lib_lwt/ocaml_lwt_kafka.c
+++ b/lib_lwt/ocaml_lwt_kafka.c
@@ -78,7 +78,7 @@ value ocaml_kafka_consume_job(value caml_kafka_topic, value caml_kafka_partition
 
   job->caml_kafka_topic = caml_kafka_topic;
   caml_register_generational_global_root(&(job->caml_kafka_topic));
-  job->topic = get_handler(Field(caml_kafka_topic,0));
+  job->topic = get_handler(caml_kafka_topic);
   job->partition = Int_val(caml_kafka_partition);
   job->timeout = Int_val(caml_kafka_timeout);
 
@@ -218,7 +218,7 @@ value ocaml_kafka_consume_batch_job(value caml_kafka_topic, value caml_kafka_par
 
   job->caml_kafka_topic = caml_kafka_topic;
   caml_register_generational_global_root(&(job->caml_kafka_topic));
-  job->topic = get_handler(Field(caml_kafka_topic,0));
+  job->topic = get_handler(caml_kafka_topic);
   job->partition = Int_val(caml_kafka_partition);
   job->timeout = Int_val(caml_kafka_timeout);
   job->msg_count = msg_count;


### PR DESCRIPTION
`Kafka.topic` was defined as a block with a reference to the rdkafka topic and the name. rdkafka offers a way to determine the name of a topic from a topic handle so the OCaml string does not need to be retained.

This makes retrieving the name an action that allocates, but on the other hand a lot of other operations in the binding avoid one level of redirection so this might be a net win and prevents the information in the OCaml string to fall out of alignment from the name that rdkafka uses (e.g. due to bugs in the binding).

I was working on Async bindings, so when I looked at the way `topic` is defined I couldn't figure out the purpose of storing the name, hence I tried removing and yes, it seems to work just fine.