### PR TITLE
Update Travis configuration according to linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
-sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
+os: linux
 dist: bionic
 cache:
     directories:
@@ -26,7 +26,7 @@ before_install:
     - kafka/bin/kafka-server-start.sh kafka/config/server.properties &
     - sleep 5
     - kafka/bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 2 --topic test
-matrix:
+jobs:
   include:
   - os: linux
     env: OCAML_VERSION=4.02 PACKAGE="kafka"     PINS="kafka.dev:."


### PR DESCRIPTION
While looking at a PR I submitted I noticed that Travis now has a linter that runs on the configuration:

<img width="471" alt="Screenshot 2020-02-25 at 14 42 30" src="https://user-images.githubusercontent.com/121531/75252525-277b4380-57dd-11ea-8464-17c2d0e272a7.png">

None of these points is particularly important but I decided to make it happy anyway. Everyone loves seeing green successes instead of yellow warnings.