### PR TITLE
Add depexts for NetBSD and FreeBSD

### DIFF
--- a/kafka.opam.template
+++ b/kafka.opam.template
@@ -6,4 +6,7 @@ depexts: [
   ["librdkafka-devel"] {os-distribution = "fedora"}
   ["librdkafka"] {os-distribution = "homebrew" & os = "macos"}
   ["librdkafka-dev"] {os-distribution = "ubuntu"}
+  ["librdkafka"] {os = "freebsd"}
+  ["librdkafka"] {os = "netbsd"}
+  ["librdkafka"] {os = "dragonfly"}
 ]


### PR DESCRIPTION
opam-repository has a FreeBSD instance to build on and there is a `net/librdkafka` port.

While at it, NetBSD also has a `devel/librdkafka` port so might as well at it at this point. Similarly, DragonflyBSD has `net/librdkafka`.

It does not seem like OpenBSD has a librdkafka port.

It is unclear to me whether `depexts` are supposed to have the category prefix. Existing packages in opam-repository seem to be split on that.