### PR TITLE
Make it possible to react on rebalance

### DIFF
--- a/lib_async/kafka_async.ml
+++ b/lib_async/kafka_async.ml
@@ -66,7 +66,9 @@ let new_producer xs =
       ignore (poll' handler));
   return { handler; pending_msg; stop_poll }
 
-external new_consumer' : (string * string) list -> Kafka.handler response
+external new_consumer' :
+  ?rebalance_callback:(unit -> unit) ->
+  (string * string) list -> Kafka.handler response
   = "ocaml_kafka_async_new_consumer"
 
 external consumer_poll' : Kafka.handler -> Kafka.message option response
@@ -80,12 +82,12 @@ let handle_incoming_message subscriptions = function
       | None -> ()
       | Some writer -> Pipe.write_without_pushback writer msg)
 
-let new_consumer xs =
+let new_consumer ?rebalance_callback xs =
   let open Result.Let_syntax in
   let subscriptions = String.Table.create ~size:(8 * 1024) () in
   let stop_poll = Ivar.create () in
   let start_poll = Ivar.create () in
-  let%bind handler = new_consumer' xs in
+  let%bind handler = new_consumer' ?rebalance_callback xs in
   every ~start:(Ivar.read start_poll) ~stop:(Ivar.read stop_poll) poll_interval
     (fun () ->
       match consumer_poll' handler with

--- a/lib_async/kafka_async.mli
+++ b/lib_async/kafka_async.mli
@@ -16,7 +16,7 @@ val produce :
 
 val new_producer : (string * string) list -> producer response
 
-val new_consumer : (string * string) list -> consumer response
+val new_consumer : ?rebalance_callback:(unit -> unit) -> (string * string) list -> consumer response
 
 val new_topic :
   producer -> string -> (string * string) list -> Kafka.topic response


### PR DESCRIPTION
I am attempting to implement batching using the modern Kafka API and for this I need to do a few steps as described in [this comment by the author of librdkafka](https://github.com/edenhill/librdkafka/issues/3093#issuecomment-701289208). One of them is to be able to flush the messages that I have collected so far when a rebalance has happened. This adds (minimal) support to notify the OCaml code when this has happened.

Let me know what you think. In particular this does not (yet?) allow the OCaml code to influence the partitioning, it just does essentially what the documentation gives example of a callback.