### PR TITLE
Expose function for storing consumer offset manually

### DIFF
--- a/lib/kafka.ml
+++ b/lib/kafka.ml
@@ -126,3 +126,5 @@ let all_topics_metadata ?(timeout_ms = 1000) handler = get_topics_metadata handl
 
 external get_librdkafka_version: unit -> string = "ocaml_kafka_get_librdkafka_version"
 let librdkafka_version = get_librdkafka_version ()
+
+external offset_store: topic -> partition -> offset -> unit = "ocaml_kafka_offset_store"

--- a/lib/kafka.mli
+++ b/lib/kafka.mli
@@ -280,3 +280,5 @@ val local_topics_metadata: ?timeout_ms:int -> handler -> Metadata.topic_metadata
 (** Information of all topics known by the brokers. *)
 val all_topics_metadata: ?timeout_ms:int -> handler -> Metadata.topic_metadata list
 
+(* Store the consumer offset of a particular partition to a specific offset *)
+val offset_store: topic -> partition -> offset -> unit

--- a/lib/ocaml_kafka.c
+++ b/lib/ocaml_kafka.c
@@ -954,3 +954,19 @@ value ocaml_kafka_get_librdkafka_version(value unit)
 
   CAMLreturn(caml_version);
 }
+
+extern CAMLprim
+value ocaml_kafka_offset_store(value caml_kafka_topic, value caml_partition, value caml_offset)
+{
+  CAMLparam3(caml_kafka_topic, caml_partition, caml_offset);
+  rd_kafka_topic_t *rkt = get_handler(caml_kafka_topic);
+  int32_t partition = Int_val(caml_partition);
+  int64_t offset = Int64_val(caml_offset);
+
+  rd_kafka_resp_err_t err = rd_kafka_offset_store(rkt, partition, offset);
+  if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+    RAISE(err, "Topic '%s' partition %ld storing offset %lld failed", rd_kafka_topic_name(rkt), partition, offset);
+  }
+
+  CAMLreturn(Val_unit);
+}


### PR DESCRIPTION
Similar to #27 this also exposes a function required to implement batching with balanced consumer groups. In this case the extension is quite straightforward, it essentially just exposes the C function to OCaml.