### PR TITLE
async: fix hang on `Kafka.destroy_handler consumer`

### DIFF
--- a/lib_async/ocaml_async_kafka.c
+++ b/lib_async/ocaml_async_kafka.c
@@ -214,6 +214,7 @@ CAMLprim value ocaml_kafka_async_consumer_poll(value caml_kafka_handler) {
     option = caml_alloc_small(1, 0);
     Field(option, 0) = ocaml_kafka_async_extract_message(rkm);
     result = OK(option);
+    rd_kafka_message_destroy(rkm);
   }
 
   CAMLreturn(result);

--- a/lib_async/ocaml_async_kafka.c
+++ b/lib_async/ocaml_async_kafka.c
@@ -214,8 +214,8 @@ CAMLprim value ocaml_kafka_async_consumer_poll(value caml_kafka_handler) {
     option = caml_alloc_small(1, 0);
     Field(option, 0) = ocaml_kafka_async_extract_message(rkm);
     result = OK(option);
-    rd_kafka_message_destroy(rkm);
   }
+  rd_kafka_message_destroy(rkm);
 
   CAMLreturn(result);
 }


### PR DESCRIPTION
from https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md#termination :

> The destructor (rd_kafka_destroy()) will block until all background threads have terminated.
> 
> If the destructor blocks indefinitely it typically means there is an outstanding object reference, such as a message or topic > object, that was not destroyed prior to destroying the client handle.

There might be missing calls to `rd_kafka_message_destroy` in the `kafka` library C stubs, but I haven't tried those yet.