### PR TITLE
add `-lzstd` to c_library_flags

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (public_name kafka)
  ; the -I and -L flags are required for freebsd, harmless elsewhere
  (foreign_stubs (language c) (names ocaml_kafka) (flags -I/usr/local/include -Wall -Werror))
- (c_library_flags -L/usr/local/lib -lrdkafka -lpthread -lz))
+ (c_library_flags -L/usr/local/lib -lzstd -lrdkafka -lpthread -lz))


### PR DESCRIPTION
- When compiling in musl64 switch with `-static`, the linker fails to find the zstd symbols
- `lib/dune` was missing `-lzstd` in `c_library_flags`


example of the error that led me to find this:

<details>

```
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: /nix/store/lf5glb9ya4561aq2155hj753zzb6rd26-rdkafka-x86_64-unknown-linux-musl-2.0.2/lib/librdkafka.a(rdkafka_zstd.o): in function `rd_kafka_zstd_decompress':
(.text+0xad): undefined reference to `ZSTD_getFrameContentSize'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0xf4): undefined reference to `ZSTD_getErrorCode'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x157): undefined reference to `ZSTD_decompress'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x162): undefined reference to `ZSTD_isError'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x2a3): undefined reference to `ZSTD_getErrorName'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: /nix/store/lf5glb9ya4561aq2155hj753zzb6rd26-rdkafka-x86_64-unknown-linux-musl-2.0.2/lib/librdkafka.a(rdkafka_zstd.o): in function `rd_kafka_zstd_compress':
(.text+0x3fd): undefined reference to `ZSTD_compressBound'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x41d): undefined reference to `ZSTD_createCStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x43d): undefined reference to `ZSTD_initCStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x448): undefined reference to `ZSTD_isError'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x468): undefined reference to `ZSTD_freeCStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x4e8): undefined reference to `ZSTD_compressStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x4f3): undefined reference to `ZSTD_isError'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x543): undefined reference to `ZSTD_getErrorName'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x591): undefined reference to `ZSTD_freeCStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x6b2): undefined reference to `ZSTD_getErrorName'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x6e9): undefined reference to `ZSTD_endStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x6f4): undefined reference to `ZSTD_isError'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x729): undefined reference to `ZSTD_freeCStream'
/nix/store/lsf839vc6aqvxlr9gimv3x71p9h6dj5l-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: (.text+0x7ed): undefined reference to `ZSTD_getErrorName'
collect2: error: ld returned 1 exit status

```

</details>