### PR TITLE
kafka: replace flags with a dune-configurator discovery script

### DIFF
--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,0 +1,21 @@
+module C = Configurator.V1
+
+(* the -I and -L flags are required for freebsd, harmless elsewhere *)
+let default : C.Pkg_config.package_conf =
+  { libs = [ "-L/usr/local/lib"; "-lrdkafka"; "-lpthread"; "-lz" ]
+  ; cflags = [ "-I/usr/local/include" ]
+  }
+
+let () =
+  C.main ~name:"kafka" (fun c ->
+      let default = default in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc ->
+          (match C.Pkg_config.query pc ~package:"rdkafka" with
+          | Some s -> s
+          | None -> default)
+      in
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags)

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -1,0 +1,4 @@
+(executables
+  (names discover)
+  (libraries dune.configurator)
+)

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,17 @@
 (library
  (name kafka)
  (public_name kafka)
- ; the -I and -L flags are required for freebsd, harmless elsewhere
- (foreign_stubs (language c) (names ocaml_kafka) (flags -I/usr/local/include -Wall -Werror))
- (c_library_flags -L/usr/local/lib -lrdkafka -lpthread -lz))
+ (foreign_stubs
+  (language c)
+  (names ocaml_kafka)
+  (flags
+   (:include c_flags.sexp)
+   -Wall
+   -Werror))
+ (c_library_flags
+  (:include c_library_flags.sexp)))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action
+  (run ./config/discover.exe)))


### PR DESCRIPTION
- This is an alternative to #36 that uses `pkg-config` through `dune-configurator` to find the required C include / library flags for the `kafka` library
